### PR TITLE
Expose dgeasb with "dupl" to C interface

### DIFF
--- a/cbind/base/psb_c_dbase.h
+++ b/cbind/base/psb_c_dbase.h
@@ -31,6 +31,7 @@ psb_i_t    psb_c_dgeins(psb_i_t nz, const psb_l_t *irw, const psb_d_t *val,
 psb_i_t    psb_c_dgeins_add(psb_i_t nz, const psb_l_t *irw, const psb_d_t *val,
 			psb_c_dvector *xh, psb_c_descriptor *cdh);
 psb_i_t    psb_c_dgeasb(psb_c_dvector *xh, psb_c_descriptor *cdh);
+psb_i_t    psb_c_dgeasb_options(psb_c_dvector *xh, psb_c_descriptor *cdh, psb_i_t dupl);
 psb_i_t    psb_c_dgefree(psb_c_dvector *xh, psb_c_descriptor *cdh);
 psb_d_t    psb_c_dgetelem(psb_c_dvector *xh,psb_l_t index,psb_c_descriptor *cd);
 

--- a/cbind/base/psb_d_tools_cbind_mod.F90
+++ b/cbind/base/psb_d_tools_cbind_mod.F90
@@ -129,6 +129,39 @@ contains
     return
   end function psb_c_dgeasb
 
+function psb_c_dgeasb_options(xh,cdh,dupl) bind(c) result(res)
+
+    implicit none
+    integer(psb_c_ipk_) :: res
+    type(psb_c_dvector) :: xh
+    type(psb_c_descriptor) :: cdh
+    integer(psb_c_ipk_), value :: dupl
+
+
+    type(psb_desc_type), pointer :: descp
+    type(psb_d_vect_type), pointer :: xp
+    integer(psb_c_ipk_)               :: info
+
+    res = -1
+
+    if (c_associated(cdh%item)) then
+      call c_f_pointer(cdh%item,descp)
+    else
+      return
+    end if
+    if (c_associated(xh%item)) then
+      call c_f_pointer(xh%item,xp)
+    else
+      return
+    end if
+
+    call psb_geasb(xp,descp,info,dupl=dupl)
+    res = min(0,info)
+
+    return
+  end function psb_c_dgeasb_options
+
+
   function psb_c_dgefree(xh,cdh) bind(c) result(res)
 
     implicit none


### PR DESCRIPTION
This PR exposes to the C interface the "dupl" argument of `psb_c_dgeasb()`.