### PR TITLE
Fix undefined references in C interface

### DIFF
--- a/cbind/test/pdegen/Makefile
+++ b/cbind/test/pdegen/Makefile
@@ -9,7 +9,7 @@ FINCLUDES=$(FMFLAG). $(FMFLAG)$(HERE) $(FMFLAG)$(MODDIR)
 CINCLUDES=-I. -I$(HERE) -I$(INCLUDEDIR)
 
 PSBC_LIBS= -L$(LIBDIR) -lpsb_cbind
-PSB_LIBS=-lpsb_util -lpsb_linsolve -lpsb_prec -lpsb_base -L$(LIBDIR)
+PSB_LIBS=-lpsb_util -lpsb_linsolve -lpsb_prec -lpsb_ext -lpsb_base -L$(LIBDIR)
 
 #
 # Compilers and such


### PR DESCRIPTION
Related to #32 

The Makefile is missing `-lpsb_ext` in the library link line, causing undefined references to sparse matrix format symbols.
From the deal.II side, `psb_ext` must be included in the PSBLAS libraries list in the CMake configuration, e.g.:
`set(_psblas_libs "psb_cbind;psb_util;psb_linsolve;psb_prec;psb_ext;psb_base")`
