### PR TITLE
Add reinit with "clear" option to C interface

### DIFF
--- a/cbind/base/psb_c_cbase.h
+++ b/cbind/base/psb_c_cbase.h
@@ -37,6 +37,7 @@ psb_i_t    psb_c_cgeasb_options(psb_c_cvector *xh, psb_c_descriptor *cdh, psb_i_
 psb_i_t	   psb_c_cgeasb_options_format(psb_c_cvector *xh, psb_c_descriptor *cdh,
 										const char *fmt, psb_i_t dupl);
 psb_i_t    psb_c_cgefree(psb_c_cvector *xh, psb_c_descriptor *cdh);
+psb_i_t    psb_c_cgereinit(psb_c_cvector *xh, psb_c_descriptor *cdh, bool clear);
 psb_c_t    psb_c_cgetelem(psb_c_cvector *xh,psb_l_t index,psb_c_descriptor *cd);
 
 /* sparse matrices*/

--- a/cbind/base/psb_c_dbase.h
+++ b/cbind/base/psb_c_dbase.h
@@ -37,6 +37,7 @@ psb_i_t    psb_c_dgeasb_options(psb_c_dvector *xh, psb_c_descriptor *cdh, psb_i_
 psb_i_t	   psb_c_dgeasb_options_format(psb_c_dvector *xh, psb_c_descriptor *cdh,
 										psb_i_t dupl, const char *fmt);
 psb_i_t    psb_c_dgefree(psb_c_dvector *xh, psb_c_descriptor *cdh);
+psb_i_t    psb_c_dgereinit(psb_c_dvector *xh, psb_c_descriptor *cdh, bool clear);
 psb_d_t    psb_c_dgetelem(psb_c_dvector *xh,psb_l_t index,psb_c_descriptor *cd);
 
 /* sparse matrices*/

--- a/cbind/base/psb_c_sbase.h
+++ b/cbind/base/psb_c_sbase.h
@@ -37,6 +37,7 @@ psb_i_t    psb_c_sgeasb_options(psb_c_svector *xh, psb_c_descriptor *cdh, psb_i_
 psb_i_t	   psb_c_sgeasb_options_format(psb_c_svector *xh, psb_c_descriptor *cdh,
 										const char *fmt, psb_i_t dupl);
 psb_i_t    psb_c_sgefree(psb_c_svector *xh, psb_c_descriptor *cdh);
+psb_i_t    psb_c_sgereinit(psb_c_svector *xh, psb_c_descriptor *cdh, bool clear);
 psb_s_t    psb_c_sgetelem(psb_c_svector *xh,psb_l_t index,psb_c_descriptor *cd);
 
 /* sparse matrices*/

--- a/cbind/base/psb_c_tools_cbind_mod.F90
+++ b/cbind/base/psb_c_tools_cbind_mod.F90
@@ -253,6 +253,40 @@ contains
   end function psb_c_cgefree
 
 
+  function psb_c_cgereinit(xh,cdh,clear) bind(c) result(res)
+
+    implicit none
+    integer(psb_c_ipk_)        :: res
+    type(psb_c_cvector)        :: xh
+    type(psb_c_descriptor)     :: cdh
+    logical(c_bool), value     :: clear
+
+    type(psb_desc_type), pointer    :: descp
+    type(psb_c_vect_type), pointer  :: xp
+    integer(psb_c_ipk_)            :: info
+    logical                         :: fclear
+
+    res = -1
+
+    if (c_associated(cdh%item)) then
+      call c_f_pointer(cdh%item,descp)
+    else
+      return
+    end if
+    if (c_associated(xh%item)) then
+      call c_f_pointer(xh%item,xp)
+    else
+      return
+    end if
+
+    fclear = clear
+    call xp%reinit(info, clear=fclear)
+    res = min(0,info)
+
+    return
+  end function psb_c_cgereinit
+
+
   function psb_c_cgeins(nz,irw,val,xh,cdh) bind(c) result(res)
 
     implicit none

--- a/cbind/base/psb_c_zbase.h
+++ b/cbind/base/psb_c_zbase.h
@@ -37,6 +37,7 @@ psb_i_t    psb_c_zgeasb_options(psb_c_zvector *xh, psb_c_descriptor *cdh, psb_i_
 psb_i_t	   psb_c_zgeasb_options_format(psb_c_zvector *xh, psb_c_descriptor *cdh,
 										const char *fmt, psb_i_t dupl);
 psb_i_t    psb_c_zgefree(psb_c_zvector *xh, psb_c_descriptor *cdh);
+psb_i_t    psb_c_zgereinit(psb_c_zvector *xh, psb_c_descriptor *cdh, bool clear);
 psb_z_t    psb_c_zgetelem(psb_c_zvector *xh,psb_l_t index,psb_c_descriptor *cd);
 
 /* sparse matrices*/

--- a/cbind/base/psb_d_tools_cbind_mod.F90
+++ b/cbind/base/psb_d_tools_cbind_mod.F90
@@ -253,6 +253,40 @@ contains
   end function psb_c_dgefree
 
 
+  function psb_c_dgereinit(xh,cdh,clear) bind(c) result(res)
+
+    implicit none
+    integer(psb_c_ipk_)        :: res
+    type(psb_c_dvector)        :: xh
+    type(psb_c_descriptor)     :: cdh
+    logical(c_bool), value     :: clear
+
+    type(psb_desc_type), pointer    :: descp
+    type(psb_d_vect_type), pointer  :: xp
+    integer(psb_c_ipk_)            :: info
+    logical                         :: fclear
+
+    res = -1
+
+    if (c_associated(cdh%item)) then
+      call c_f_pointer(cdh%item,descp)
+    else
+      return
+    end if
+    if (c_associated(xh%item)) then
+      call c_f_pointer(xh%item,xp)
+    else
+      return
+    end if
+
+    fclear = clear
+    call xp%reinit(info, clear=fclear)
+    res = min(0,info)
+
+    return
+  end function psb_c_dgereinit
+
+
   function psb_c_dgeins(nz,irw,val,xh,cdh) bind(c) result(res)
 
     implicit none

--- a/cbind/base/psb_s_tools_cbind_mod.F90
+++ b/cbind/base/psb_s_tools_cbind_mod.F90
@@ -253,6 +253,40 @@ contains
   end function psb_c_sgefree
 
 
+  function psb_c_sgereinit(xh,cdh,clear) bind(c) result(res)
+
+    implicit none
+    integer(psb_c_ipk_)        :: res
+    type(psb_c_svector)        :: xh
+    type(psb_c_descriptor)     :: cdh
+    logical(c_bool), value     :: clear
+
+    type(psb_desc_type), pointer    :: descp
+    type(psb_s_vect_type), pointer  :: xp
+    integer(psb_c_ipk_)            :: info
+    logical                         :: fclear
+
+    res = -1
+
+    if (c_associated(cdh%item)) then
+      call c_f_pointer(cdh%item,descp)
+    else
+      return
+    end if
+    if (c_associated(xh%item)) then
+      call c_f_pointer(xh%item,xp)
+    else
+      return
+    end if
+
+    fclear = clear
+    call xp%reinit(info, clear=fclear)
+    res = min(0,info)
+
+    return
+  end function psb_c_sgereinit
+
+
   function psb_c_sgeins(nz,irw,val,xh,cdh) bind(c) result(res)
 
     implicit none

--- a/cbind/base/psb_z_tools_cbind_mod.F90
+++ b/cbind/base/psb_z_tools_cbind_mod.F90
@@ -253,6 +253,40 @@ contains
   end function psb_c_zgefree
 
 
+  function psb_c_zgereinit(xh,cdh,clear) bind(c) result(res)
+
+    implicit none
+    integer(psb_c_ipk_)        :: res
+    type(psb_c_zvector)        :: xh
+    type(psb_c_descriptor)     :: cdh
+    logical(c_bool), value     :: clear
+
+    type(psb_desc_type), pointer    :: descp
+    type(psb_z_vect_type), pointer  :: xp
+    integer(psb_c_ipk_)            :: info
+    logical                         :: fclear
+
+    res = -1
+
+    if (c_associated(cdh%item)) then
+      call c_f_pointer(cdh%item,descp)
+    else
+      return
+    end if
+    if (c_associated(xh%item)) then
+      call c_f_pointer(xh%item,xp)
+    else
+      return
+    end if
+
+    fclear = clear
+    call xp%reinit(info, clear=fclear)
+    res = min(0,info)
+
+    return
+  end function psb_c_zgereinit
+
+
   function psb_c_zgeins(nz,irw,val,xh,cdh) bind(c) result(res)
 
     implicit none


### PR DESCRIPTION
Adds the function `psb_c_dgereinit` to the C interface, with a `clear` argument to control reinitialization behavior.