### PR TITLE
Fix status value in reinit function

### DIFF
--- a/base/modules/serial/psb_c_base_vect_mod.F90
+++ b/base/modules/serial/psb_c_base_vect_mod.F90
@@ -426,6 +426,8 @@ contains
     integer(psb_ipk_), intent(out)              :: info
     logical, intent(in), optional               :: clear
     logical :: clear_
+  
+    info = 0
 
     if (present(clear)) then
       clear_ = clear

--- a/base/modules/serial/psb_d_base_vect_mod.F90
+++ b/base/modules/serial/psb_d_base_vect_mod.F90
@@ -434,6 +434,8 @@ contains
     logical, intent(in), optional               :: clear
     logical :: clear_
 
+    info = 0
+    
     if (present(clear)) then
       clear_ = clear
     else

--- a/base/modules/serial/psb_s_base_vect_mod.F90
+++ b/base/modules/serial/psb_s_base_vect_mod.F90
@@ -434,6 +434,8 @@ contains
     logical, intent(in), optional               :: clear
     logical :: clear_
 
+    info = 0
+    
     if (present(clear)) then
       clear_ = clear
     else

--- a/base/modules/serial/psb_z_base_vect_mod.F90
+++ b/base/modules/serial/psb_z_base_vect_mod.F90
@@ -427,6 +427,8 @@ contains
     logical, intent(in), optional               :: clear
     logical :: clear_
 
+    info = 0
+
     if (present(clear)) then
       clear_ = clear
     else


### PR DESCRIPTION
`info` is declared `intent(out)` but never assigned a value on the success path