### PR TITLE
Replace _Bool with bool in C interface headers for C++ compatibility

### DIFF
--- a/cbind/base/psb_c_cbase.h
+++ b/cbind/base/psb_c_cbase.h
@@ -62,7 +62,7 @@ psb_i_t		 psb_c_ccopy_mat(psb_c_cspmat *ah,psb_c_cspmat *bh,psb_c_descriptor *cd
 
 psb_i_t    psb_c_cspasb_opt(psb_c_cspmat *mh, psb_c_descriptor *cdh,  
  			const char *afmt, psb_i_t upd, psb_i_t dupl); 
-psb_i_t    psb_c_csprn(psb_c_cspmat *mh, psb_c_descriptor *cdh, _Bool clear);
+psb_i_t    psb_c_csprn(psb_c_cspmat *mh, psb_c_descriptor *cdh, bool clear);
 psb_i_t    psb_c_cmat_name_print(psb_c_cspmat *mh, char *name);
 psb_i_t	   psb_c_cvect_set_scal(psb_c_cvector *xh, psb_c_t val);
 psb_i_t	   psb_c_cvect_set_vect(psb_c_cvector *xh, psb_c_t *val, psb_i_t n);

--- a/cbind/base/psb_c_dbase.h
+++ b/cbind/base/psb_c_dbase.h
@@ -63,7 +63,7 @@ psb_i_t		 psb_c_dcopy_mat(psb_c_dspmat *ah,psb_c_dspmat *bh,psb_c_descriptor *cd
 
 psb_i_t    psb_c_dspasb_opt(psb_c_dspmat *mh, psb_c_descriptor *cdh,
  			const char *afmt, psb_i_t upd, psb_i_t dupl); 
-psb_i_t    psb_c_dsprn(psb_c_dspmat *mh, psb_c_descriptor *cdh, _Bool clear);
+psb_i_t    psb_c_dsprn(psb_c_dspmat *mh, psb_c_descriptor *cdh, bool clear);
 psb_i_t    psb_c_dmat_name_print(psb_c_dspmat *mh, char *name);
 psb_i_t    psb_c_dvect_set_scal(psb_c_dvector *xh, psb_d_t val);
 psb_i_t	   psb_c_dvect_set_vect(psb_c_dvector *xh, psb_d_t *val, psb_i_t n);

--- a/cbind/base/psb_c_sbase.h
+++ b/cbind/base/psb_c_sbase.h
@@ -63,7 +63,7 @@ psb_i_t		 psb_c_scopy_mat(psb_c_sspmat *ah,psb_c_sspmat *bh,psb_c_descriptor *cd
 	
  psb_i_t    psb_c_sspasb_opt(psb_c_sspmat *mh, psb_c_descriptor *cdh,
  			const char *afmt, psb_i_t upd, psb_i_t dupl); 
-psb_i_t    psb_c_ssprn(psb_c_sspmat *mh, psb_c_descriptor *cdh, _Bool clear);
+psb_i_t    psb_c_ssprn(psb_c_sspmat *mh, psb_c_descriptor *cdh, bool clear);
 psb_i_t    psb_c_smat_name_print(psb_c_sspmat *mh, char *name);
 psb_i_t	   psb_c_svect_set_scal(psb_c_svector *xh, psb_s_t val);
 psb_i_t	   psb_c_svect_set_vect(psb_c_svector *xh, psb_s_t *val, psb_i_t n);

--- a/cbind/base/psb_c_zbase.h
+++ b/cbind/base/psb_c_zbase.h
@@ -64,7 +64,7 @@ psb_i_t		 psb_c_zcopy_mat(psb_c_zspmat *ah,psb_c_zspmat *bh,psb_c_descriptor *cd
 
 psb_i_t    psb_c_zspasb_opt(psb_c_zspmat *mh, psb_c_descriptor *cdh,  
  			const char *afmt, psb_i_t upd, psb_i_t dupl); 
-psb_i_t    psb_c_zsprn(psb_c_zspmat *mh, psb_c_descriptor *cdh, _Bool clear);
+psb_i_t    psb_c_zsprn(psb_c_zspmat *mh, psb_c_descriptor *cdh, bool clear);
 psb_i_t    psb_c_zmat_name_print(psb_c_zspmat *mh, char *name);
 psb_i_t	   psb_c_zvect_set_scal(psb_c_zvector *xh, psb_z_t val);
 psb_i_t	   psb_c_zvect_set_vect(psb_c_zvector *xh, psb_z_t *val, psb_i_t n);


### PR DESCRIPTION
## Problem

The C interface headers `psb_c_dbase.h`, `psb_c_sbase.h`, `psb_c_cbase.h`, and `psb_c_zbase.h` use `_Bool` (a C11 keyword) in the `*sprn` function declarations.

When these headers are included from C++ code (via `extern "C"`), the C++ compiler fails with:

```
error: unknown type name "__Bool"
```

This is a known portability issue — `_Bool` is C-only and not recognized by C++ compilers, even though the headers are designed to be included from both C and C++ (they already use `#ifdef __cplusplus / extern "C" {`).

## Fix

Replace `_Bool` with `bool` (from `<stdbool.h>`), which is already included via `psb_c_base.h`. This type works correctly in both C (where `bool` is a `typedef` for `_Bool`) and C++ (where `bool` is a native type).

## Files changed

- `cbind/base/psb_c_dbase.h` — `psb_c_dsprn()`
- `cbind/base/psb_c_sbase.h` — `psb_c_ssprn()`
- `cbind/base/psb_c_cbase.h` — `psb_c_csprn()`
- `cbind/base/psb_c_zbase.h` — `psb_c_zsprn()`

This change has no effect on the ABI since `bool` and `_Bool` are both mapped to `int` in the C/ABI calling convention (via Fortran `bind(c)` with `logical`).